### PR TITLE
Fix issue where we were matching file names poorly for deletion.

### DIFF
--- a/albedo.js
+++ b/albedo.js
@@ -97,7 +97,8 @@ function rmDir(dirPath, options) {
       const now = moment().unix();
       const daysAgo = now - (parseInt(options.removeOlderThan, 10) * 86400);
       const fileTime = moment(fs.statSync(filePath).mtime).unix();
-      if (fileName.substring(0, options.name.length) === options.name) {
+      // get the full name of the report from the file by removing the datetime and extension
+      if (fileName.slice(0, 0-'_YYYY-MM-DD_HH-mm-ss.csv'.length) === options.name) {
         if (fileTime < daysAgo) {
           fs.unlinkSync(filePath);
           console.log(`deleted: ${filePath}`);


### PR DESCRIPTION
We had issues when deleting existing files, where one report in the folder had the same name as another but with a bit more tacked on (e.g "Incident Report" and "Incident Report - Old"). If the report for the shorter name generated second, it would delete the report with the longer name because it matched the name using the old code below:
`if (fileName.substring(0, options.name.length) === options.name) `
This changes the name matching to use the filename instead, removing the datetime and extension before matching:
`if (fileName.slice(0, 0-'_YYYY-MM-DD_HH-mm-ss.csv'.length) === options.name)`
I could have just use `slice(0,-24)`, but I used the string length for explicitness of what we were slicing off.