### PR TITLE
Modify report generation to use streaming operations

### DIFF
--- a/albedo.js
+++ b/albedo.js
@@ -1,4 +1,5 @@
-const json2csv = require('json2csv');
+const { Transform } = require('stream');
+const CSVTransform = require('json2csv').Transform;
 const mysql = require('mysql');
 const fs = require('fs');
 const moment = require('moment');
@@ -28,55 +29,67 @@ module.exports = {
       insecureAuth: true,
     });
 
-    connection.query(options.query, (err, rows) => {
-      if (err) {
-        return callback(err);
-      }
-      if (rows.length === 0) {
-        return callback('No records for query');
-      }
+    // prune older reports
+    if (options.hasOwnProperty('removeOlderThan')) {
+      rmDir(options.location, options);
+    }
 
-      let processedRows = rows;
-      // Allow calling code to pass either a function or an array of functions
-      // with which to process each row of data
-      if (_.isArray(options.process_row)) {
-        _.each(options.process_row, (func) => {
-          processedRows = _.map(processedRows, func);
-        });
-      } else if (_.isFunction(options.process_row)) {
-        processedRows = _.map(processedRows, options.process_row);
-      }
+    // set up input, csv, and output streams
+    const fileName = `${options.name}_${moment().format('YYYY-MM-DD_HH-mm-ss')}.csv`;
+    const outputPath = `${options.location}/${fileName}`;
 
-      return json2csv(
-        {
-          data: processedRows,
-          preserveNewLinesInValues: true,
-        },
-        (err1, csv) => {
-          if (err1) {
-            return callback(err1);
+    const input = connection.query(options.query).stream({ highWaterMark: 64 });
+    const output = fs.createWriteStream(outputPath, { encoding: 'utf8' });
+    const json2csv = new CSVTransform(null, { objectMode: true });
+
+    // handle row transformations
+    const rowTransform = new Transform({
+      writableObjectMode: true,
+      readableObjectMode: true,
+
+      transform(chunk, enc, handler) {
+        try {
+          let row = chunk;
+          if (_.isArray(options.process_row)) {
+            _.each(options.process_row, (func) => {
+              row = func(row);
+            });
+          } else if (_.isFunction(options.process_row)) {
+            row = options.process_row(row);
           }
-
-          if (options.hasOwnProperty('removeOlderThan')) {
-            rmDir(options.location, options);
-          }
-          // make the new report
-          const fileName = `${options.name}_${moment().format('YYYY-MM-DD_HH-mm-ss')}.csv`;
-          fs.writeFile(`${options.location}/${fileName}`, csv, (err2) => {
-            if (err2) {
-              return callback(err2);
-            }
-            const reportInfo = {
-              name: fileName,
-              path: `${options.location}/`,
-            };
-
-            return callback(null, reportInfo);
-          });
+          handler(null, row);
+        } catch (e) {
+          handler(e);
         }
-      );
+      },
     });
 
+    // route errors from streams to callback
+    let wasError = false;
+    function forwardError(e) {
+      wasError = true;
+      callback(e);
+    }
+    input.on('error', forwardError);
+    rowTransform.on('error', forwardError);
+    json2csv.on('error', forwardError);
+    output.on('error', forwardError);
+
+    // route output stream finish event to callback
+    output.on('close', () => {
+      if (wasError) {
+        // suppress final report info callback on errors
+        return;
+      }
+      const reportInfo = {
+        name: fileName,
+        path: `${options.location}/`,
+      };
+      callback(null, reportInfo);
+    });
+
+    // stream query results through processing pipeline
+    input.pipe(rowTransform).pipe(json2csv).pipe(output);
     connection.end();
   },
 };

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/waytohealth/albedo/issues"
   },
   "dependencies": {
-    "json2csv": "^3.11.5",
+    "json2csv": "^4.3.4",
     "moment": "^2.19.2",
     "mysql": "^2.15.0",
     "underscore": "^1.7.0"


### PR DESCRIPTION
As a quick overview, this involved:

1. Changing the MySQL query method to use `stream` in place of the function callback.
1. Updating the `json2csv` dependency to a new version that supports stream-based inputs and outputs.
1. Wiring both of those together via `pipe` in a way that propagates errors correctly.

For queries with lots of rows, this has a pretty dramatic positive impact on memory usage.

This change does not modify Albedo's API at all. The only behavioral changes are that partial report files are left in place if an error occurs while processing the query results, and queries with zero results no longer throw errors.